### PR TITLE
Add proxy protocol v2 client-side support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Flags:
       --nginx.ssl-client-cert=""
                                  Path to the PEM encoded client certificate file to use when connecting to the server. ($SSL_CLIENT_CERT)
       --nginx.ssl-client-key=""  Path to the PEM encoded client certificate key file to use when connecting to the server. ($SSL_CLIENT_KEY)
+      --[no-]nginx.proxy-protocol
+                                 Pass proxy protocol payload to nginx listeners. ($PROXY_PROTOCOL)
       --nginx.timeout=5s         A timeout for scraping metrics from NGINX or NGINX Plus. ($TIMEOUT)
       --prometheus.const-label=PROMETHEUS.CONST-LABEL ...
                                  Label that will be used in every metric. Format is label=value. It can be repeated multiple times. ($CONST_LABELS)

--- a/exporter.go
+++ b/exporter.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
+
+	proxyproto "github.com/pires/go-proxyproto"
 )
 
 // positiveDuration is a wrapper of time.Duration to ensure only positive values are accepted.
@@ -90,6 +92,7 @@ var (
 	sslCaCert     = kingpin.Flag("nginx.ssl-ca-cert", "Path to the PEM encoded CA certificate file used to validate the servers SSL certificate.").Default("").Envar("SSL_CA_CERT").String()
 	sslClientCert = kingpin.Flag("nginx.ssl-client-cert", "Path to the PEM encoded client certificate file to use when connecting to the server.").Default("").Envar("SSL_CLIENT_CERT").String()
 	sslClientKey  = kingpin.Flag("nginx.ssl-client-key", "Path to the PEM encoded client certificate key file to use when connecting to the server.").Default("").Envar("SSL_CLIENT_KEY").String()
+	useProxyProto = kingpin.Flag("nginx.proxy-protocol", "Pass proxy protocol payload to nginx listeners.").Default("false").Envar("PROXY_PROTOCOL").Bool()
 
 	// Custom command-line flags.
 	timeout = createPositiveDurationFlag(kingpin.Flag("nginx.timeout", "A timeout for scraping metrics from NGINX or NGINX Plus.").Default("5s").Envar("TIMEOUT").HintOptions("5s", "10s", "30s", "1m", "5m"))
@@ -223,18 +226,66 @@ func main() {
 func registerCollector(logger *slog.Logger, transport *http.Transport,
 	addr string, labels map[string]string,
 ) {
+	var socketPath string
+
 	if strings.HasPrefix(addr, "unix:") {
-		socketPath, requestPath, err := parseUnixSocketAddress(addr)
+		var err error
+		var requestPath string
+		socketPath, requestPath, err = parseUnixSocketAddress(addr)
 		if err != nil {
 			logger.Error("parsing unix domain socket scrape address failed", "uri", addr, "error", err.Error())
 			os.Exit(1)
 		}
+		addr = "http://unix" + requestPath
+	}
 
+	if !*useProxyProto && socketPath != "" {
 		transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := &net.Dialer{}
 			return d.DialContext(ctx, "unix", socketPath)
 		}
-		addr = "http://unix" + requestPath
+	}
+
+	if *useProxyProto {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if socketPath != "" {
+				network = "unix"
+				addr = socketPath
+			}
+
+			conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, fmt.Errorf("dialing %s %s: %w", network, addr, err)
+			}
+
+			localAddr := conn.LocalAddr()
+			remoteAddr := conn.RemoteAddr()
+			transportProtocol := proxyproto.TCPv4
+
+			switch addr := remoteAddr.(type) {
+			case *net.TCPAddr:
+				if addr.IP.To4() == nil {
+					transportProtocol = proxyproto.TCPv6
+				}
+			case *net.UnixAddr:
+				transportProtocol = proxyproto.UnixStream
+			}
+
+			header := &proxyproto.Header{
+				Version:           2,
+				Command:           proxyproto.PROXY,
+				TransportProtocol: transportProtocol,
+				SourceAddr:        localAddr,
+				DestinationAddr:   remoteAddr,
+			}
+
+			_, err = header.WriteTo(conn)
+			if err != nil {
+				return nil, fmt.Errorf("writing proxyproto header: %w", err)
+			}
+
+			return conn, nil
+		}
 	}
 
 	userAgent := fmt.Sprintf("NGINX-Prometheus-Exporter/v%v", common_version.Version)

--- a/exporter.go
+++ b/exporter.go
@@ -281,8 +281,9 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 
 			// as we do not use any TLVs, header size should be pretty small, hence we only check for error, assuming the whole header went out in a single packet
 			_, err = header.WriteTo(conn)
-			if err != nil {
-				return nil, fmt.Errorf("writing proxyproto header: %w", err)
+			if err == nil {
+				conn.Close()
+				return nil, fmt.Errorf("writing proxyproto header via %s to %s: %w", network, addr, err)
 			}
 
 			return conn, nil

--- a/exporter.go
+++ b/exporter.go
@@ -262,9 +262,9 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 			remoteAddr := conn.RemoteAddr()
 			transportProtocol := proxyproto.TCPv4
 
-			switch addr := remoteAddr.(type) {
+			switch remoteAddrTyped := remoteAddr.(type) {
 			case *net.TCPAddr:
-				if addr.IP.To4() == nil {
+				if remoteAddrTyped.IP.To4() == nil {
 					transportProtocol = proxyproto.TCPv6
 				}
 			case *net.UnixAddr:
@@ -279,6 +279,7 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 				DestinationAddr:   remoteAddr,
 			}
 
+			// as we do not use any TLVs, header size should be pretty small, hence we only check for error, assuming the whole header went out in a single packet
 			_, err = header.WriteTo(conn)
 			if err != nil {
 				return nil, fmt.Errorf("writing proxyproto header: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/nginx/nginx-plus-go-client/v3 v3.0.0
 	github.com/prometheus/client_golang v1.23.0
+	github.com/pires/go-proxyproto v0.8.1
 	github.com/prometheus/common v0.65.0
 	github.com/prometheus/exporter-toolkit v0.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nginx/nginx-plus-go-client/v3 v3.0.0 h1:toZ6X4+4zhUkifYvUdiAaAe4tlq+Y7c03Ns4zb/2ytY=
 github.com/nginx/nginx-plus-go-client/v3 v3.0.0/go.mod h1:sCHx+oXai55zsoco5IKSIsVoDH6dEAMtlw9qjkJ9gFM=
+github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
+github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.0 h1:ust4zpdl9r4trLY/gSjlm07PuiBq2ynaXXlptpfy8Uc=


### PR DESCRIPTION
### Proposed changes

This PR introduces support for [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) v2 which is [available in nginx](https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/) starting from versions 1.13.11 (foss) and R16 (NGINX Plus).

Primary use case is running nginx-prometheus-exporter alongside with nginx or NGINX Plus sitting behind other load balancers like AWS [NLB](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) or Google's [PNLB](https://cloud.google.com/load-balancing/docs/proxy-network-load-balancer) with proxy protocol enabled. Sometimes creating dedicated listeners just for [stub_status](nginx.org/r/stub_status) or [API](nginx.org/r/api) could be undesired, and with the proposed changes the exporter will be able to reuse existing listeners without extra effort.

Changes were tested with the following combinations of listeners:
1. IPv4 with `proxy_protocol`, IPv4 without `proxy_protocol`.
2. IPv6 with `proxy_protocol`, IPv6 without `proxy_protocol`.
3. Unix socket with `proxy_protocol`, unix socket without `proxy_protocol` (not that common scenario, but still supported by standard).

Implementation used: https://github.com/pires/go-proxyproto

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
