### PR TITLE
Use Go version defined in go.mod for running Go linter action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          #go-version: stable
           go-version: '1.23.6'
 
       - name: Lint Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.23.6'
+          go-version-file: go.mod
 
       - name: Lint Go
         uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: stable
+          #go-version: stable
+          go-version: '1.23.6'
 
       - name: Lint Go
         uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2


### PR DESCRIPTION
### Proposed changes

Use explicit Go version (defined in the `go.mod` file) to run Go linter workflow (GitHub Action - ActionLint). This way we will avoid current dependency issues on Go 1.24.

PR fixes this deps:

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint run] in [/home/runner/work/nginx-prometheus-exporter/nginx-prometheus-exporter] ...
  Error: ../../../go/pkg/mod/golang.org/x/sys@v0.29.0/unix/vgetrandom_linux.go:7:9: file requires newer Go version go1.24 (application built with go1.23) (typecheck)
  package unix
          ^
  Error: ../../../go/pkg/mod/golang.org/x/net@v0.34.0/http2/config_go124.go:7:9: file requires newer Go version go1.24 (application built with go1.23) (typecheck)
  package http2
          ^
  
  Error: issues found
  Ran golangci-lint in 23318ms
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [X] I have proven my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
