### PR TITLE
Update go.mod to use Go 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nginx/nginx-prometheus-exporter
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.24.2
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Closes #1047

### Proposed changes

Updates the main go version to 1.24.2 as well

### Considerations

If this project is used as a dependency, we need to validate that the go version bump does not interfere with other projects' functionality.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
