### PR TITLE
Switch to DialContext() to address lint issue

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -230,9 +230,9 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 			os.Exit(1)
 		}
 
-		transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := &net.Dialer{}
-			return d.DialContext(context.Background(), "unix", socketPath)
+			return d.DialContext(ctx, "unix", socketPath)
 		}
 		addr = "http://unix" + requestPath
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -231,7 +231,8 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 		}
 
 		transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("unix", socketPath)
+			d := &net.Dialer{}
+			return d.DialContext(context.Background(), "unix", socketPath)
 		}
 		addr = "http://unix" + requestPath
 	}


### PR DESCRIPTION
### Proposed changes

Address lint issue
```
  Error: exporter.go:234:19: net.Dial must not be called. use (*net.Dialer).DialContext (noctx)
  			return net.Dial("unix", socketPath)
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
