### PR TITLE
feat: add `--web.nginx-metrics-only` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Flags:
       --web.listen-address=:9113 ...
                                  Addresses on which to expose metrics and web interface. Repeatable for multiple addresses. ($LISTEN_ADDRESS)
       --web.config.file=""       Path to configuration file that can enable TLS or authentication. See: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md ($CONFIG_FILE)
+      --[no-]web.nginx-metrics-only
+                                 Expose only NGINX metrics (no Go runtime, build info, or promhttp metrics). ($NGINX_METRICS_ONLY)
       --web.telemetry-path="/metrics"
                                  Path under which to expose metrics. ($TELEMETRY_PATH)
       --[no-]nginx.plus          Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. ($NGINX_PLUS)
@@ -198,7 +200,9 @@ Flags:
 | `nginx_exporter_build_info`                  | Gauge    | Shows the exporter build information.        | `branch`, `goarch`, `goos`, `goversion`, `revision`, `tags` and `version` |
 | `promhttp_metric_handler_requests_total`     | Counter  | Total number of scrapes by HTTP status code. | `code` (the HTTP status code)                                             |
 | `promhttp_metric_handler_requests_in_flight` | Gauge    | Current number of scrapes being served.      | []                                                                        |
-| `go_*`                                       | Multiple | Go runtime metrics.                          | []                                                                        |
+| `go_*`                                       | Multiple | Go runtime metrics (disabled with `--web.nginx-metrics-only`). | []                                                                        |
+
+When `--web.nginx-metrics-only` is set, only NGINX metrics are exposed (no Go runtime, build info, or promhttp metrics).
 
 ### Metrics for NGINX OSS
 


### PR DESCRIPTION
### Proposed changes

**Add a flag `---web.nginx-metrics-only`. When the flag is set, export only Nginx metrics and skip all others.**

#### Motivation

We run this exporter (alongside others, also written in Go) in a Kubernetes environment using Kuma as the service mesh.
Metrics are aggregated per pod via Kuma sidecar's `metrics-hijacker` feature.

When multiple containers within the same pod expose Go runtime metrics, `promhttp` metrics, etc., these metrics automatically receive the Kuma sidecar’s labels. As a result, Prometheus reports duplicated metrics. This issue occurs consistently in our setup. We identified two possible approaches:

1. Discard any Go runtime metrics with Prometheus rules. (Just no)
2. Add custom labels to the Go runtime metrics. (More complex and kind of odd)
3. Make the emission of Go runtime metrics by the exporters optional. (Simple to implement, small trade-off)

**After evaluating these options, we decided to support disabling Go runtime metrics in the exporters.**

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
