### PR TITLE
Add created timestamps to NginxCollector counter metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Flags:
       --nginx.timeout=5s         A timeout for scraping metrics from NGINX or NGINX Plus. ($TIMEOUT)
       --prometheus.const-label=PROMETHEUS.CONST-LABEL ...
                                  Label that will be used in every metric. Format is label=value. It can be repeated multiple times. ($CONST_LABELS)
+      --prometheus.created-time-source="none"
+                                 Source for created timestamps on counter metrics: none, process, stats (stats is only valid with --nginx.plus). ($CREATED_TIME_SOURCE)
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
       --[no-]version             Show application version.

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -1,8 +1,13 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// nowFunc overloadable for package level testing
+var nowFunc = time.Now
 
 const (
 	nginxUp   = 1
@@ -35,3 +40,11 @@ func MergeLabels(a map[string]string, b map[string]string) map[string]string {
 
 	return c
 }
+
+type CTSource byte
+
+const (
+	CTSourceNone CTSource = iota
+	CTSourceProcess
+	CTSourceStats
+)

--- a/collector/integration_test.go
+++ b/collector/integration_test.go
@@ -1,0 +1,248 @@
+package collector
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	plusclient "github.com/nginx/nginx-plus-go-client/v3/client"
+	"github.com/nginx/nginx-prometheus-exporter/client"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+const stubStatusResponse = `Active connections: 1457
+server accepts handled requests
+ 6717066 6717066 65844359
+Reading: 1 Writing: 8 Waiting: 1448
+`
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newOSSMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, stubStatusResponse)
+	}))
+}
+
+func newPlusMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.RequestURI {
+		case "/":
+			fmt.Fprint(w, `[9]`)
+		case "/9/":
+			fmt.Fprint(w, `["nginx","processes","connections","slabs","http","resolvers","ssl"]`)
+		case "/9/nginx":
+			fmt.Fprint(w, `{"version":"1.25.0","build":"nginx-plus-r30","pid":123,"load_timestamp":"2025-06-15T12:00:00.000Z"}`)
+		case "/9/connections":
+			fmt.Fprint(w, `{"accepted":100,"dropped":5,"active":10,"idle":20}`)
+		case "/9/http/requests":
+			fmt.Fprint(w, `{"total":1000,"current":5}`)
+		case "/9/ssl":
+			fmt.Fprint(w, `{"handshakes":50,"handshakes_failed":2,"session_reuses":30}`)
+		case "/9/processes":
+			fmt.Fprint(w, `{}`)
+		case "/9/slabs":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/caches":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/server_zones":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/upstreams":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/location_zones":
+			fmt.Fprint(w, `{}`)
+		case "/9/resolvers":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/limit_reqs":
+			fmt.Fprint(w, `{}`)
+		case "/9/http/limit_conns":
+			fmt.Fprint(w, `{}`)
+		case "/9/workers":
+			fmt.Fprint(w, `[]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// gatherCreatedTimestamps calls Gather() on the registry and returns a map of
+// metric family name → created timestamp for all counter metrics that have a
+// non-nil CreatedTimestamp.
+func gatherCreatedTimestamps(t *testing.T, registry *prometheus.Registry) map[string]time.Time {
+	t.Helper()
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := make(map[string]time.Time)
+	for _, mf := range families {
+		if mf.GetType() != dto.MetricType_COUNTER {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			ct := m.GetCounter().GetCreatedTimestamp()
+			if ct != nil {
+				result[mf.GetName()] = ct.AsTime()
+				break // one per family is enough
+			}
+		}
+	}
+	return result
+}
+
+func TestCreatedTimestamp_NginxOSS_Process(t *testing.T) {
+	backend := newOSSMockServer(t)
+	defer backend.Close()
+
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = time.Now }()
+	ossClient := client.NewNginxClient(backend.Client(), backend.URL+"/stub_status")
+	col := NewNginxCollector(ossClient, "nginx", nil, newTestLogger(),
+		CTSourceProcess)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(col)
+
+	cts := gatherCreatedTimestamps(t, registry)
+
+	wantCounters := []string{
+		"nginx_connections_accepted",
+		"nginx_connections_handled",
+		"nginx_http_requests_total",
+	}
+	for _, name := range wantCounters {
+		got, ok := cts[name]
+		if !ok {
+			t.Errorf("expected created timestamp for %s but found none", name)
+			continue
+		}
+		if !got.Equal(now) {
+			t.Errorf("metric %s: got created time %v, want %v", name, got, now)
+		}
+	}
+
+	// Gauge metrics should NOT have created timestamps.
+	gauges := []string{
+		"nginx_connections_active",
+		"nginx_connections_reading",
+		"nginx_connections_writing",
+		"nginx_connections_waiting",
+	}
+	for _, name := range gauges {
+		if _, ok := cts[name]; ok {
+			t.Errorf("gauge metric %s should not have a created timestamp", name)
+		}
+	}
+}
+
+func TestCreatedTimestamp_NginxPlus_Stats(t *testing.T) {
+	backend := newPlusMockServer(t)
+	defer backend.Close()
+
+	plusClient, err := plusclient.NewNginxClient(backend.URL, plusclient.WithAPIVersion(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variableLabels := NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil)
+	col := NewNginxPlusCollector(plusClient, "nginxplus", variableLabels, nil, newTestLogger(), CTSourceStats)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(col)
+
+	cts := gatherCreatedTimestamps(t, registry)
+
+	wantTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	wantCounters := []string{
+		"nginxplus_connections_accepted",
+		"nginxplus_connections_dropped",
+		"nginxplus_http_requests_total",
+	}
+	for _, name := range wantCounters {
+		got, ok := cts[name]
+		if !ok {
+			t.Errorf("expected created timestamp for %s but found none", name)
+			continue
+		}
+		if !got.Equal(wantTime) {
+			t.Errorf("metric %s: got created time %v, want %v", name, got, wantTime)
+		}
+	}
+
+	// Gauge metrics should NOT have created timestamps.
+	gauges := []string{
+		"nginxplus_connections_active",
+		"nginxplus_connections_idle",
+	}
+	for _, name := range gauges {
+		if _, ok := cts[name]; ok {
+			t.Errorf("gauge metric %s should not have a created timestamp", name)
+		}
+	}
+}
+
+func TestCreatedTimestamp_NginxPlus_Process(t *testing.T) {
+	backend := newPlusMockServer(t)
+	defer backend.Close()
+
+	now := time.Date(2025, 7, 1, 10, 30, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = time.Now }()
+	plusClient, err := plusclient.NewNginxClient(backend.URL, plusclient.WithAPIVersion(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variableLabels := NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil)
+	col := NewNginxPlusCollector(plusClient, "nginxplus", variableLabels, nil, newTestLogger(), CTSourceProcess)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(col)
+
+	cts := gatherCreatedTimestamps(t, registry)
+
+	wantCounters := []string{
+		"nginxplus_connections_accepted",
+		"nginxplus_connections_dropped",
+		"nginxplus_http_requests_total",
+	}
+	for _, name := range wantCounters {
+		got, ok := cts[name]
+		if !ok {
+			t.Errorf("expected created timestamp for %s but found none", name)
+			continue
+		}
+		if !got.Equal(now) {
+			t.Errorf("metric %s: got created time %v, want %v", name, got, now)
+		}
+	}
+}
+
+func TestCreatedTimestamp_None(t *testing.T) {
+	backend := newOSSMockServer(t)
+	defer backend.Close()
+
+	ossClient := client.NewNginxClient(backend.Client(), backend.URL+"/stub_status")
+	col := NewNginxCollector(ossClient, "nginx", nil, newTestLogger(), CTSourceNone)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(col)
+
+	cts := gatherCreatedTimestamps(t, registry)
+
+	if len(cts) != 0 {
+		t.Errorf("expected no created timestamps with source=none, got %v", cts)
+	}
+}

--- a/collector/nginx.go
+++ b/collector/nginx.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/nginx/nginx-prometheus-exporter/client"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,11 +16,12 @@ type NginxCollector struct {
 	nginxClient *client.NginxClient
 	metrics     map[string]*prometheus.Desc
 	mutex       sync.Mutex
+	createdAt   time.Time
 }
 
 // NewNginxCollector creates an NginxCollector.
-func NewNginxCollector(nginxClient *client.NginxClient, namespace string, constLabels map[string]string, logger *slog.Logger) *NginxCollector {
-	return &NginxCollector{
+func NewNginxCollector(nginxClient *client.NginxClient, namespace string, constLabels map[string]string, logger *slog.Logger, ctSource CTSource) *NginxCollector {
+	c := &NginxCollector{
 		nginxClient: nginxClient,
 		logger:      logger,
 		metrics: map[string]*prometheus.Desc{
@@ -33,6 +35,10 @@ func NewNginxCollector(nginxClient *client.NginxClient, namespace string, constL
 		},
 		upMetric: newUpMetric(namespace, constLabels),
 	}
+	if ctSource == CTSourceProcess {
+		c.createdAt = nowFunc()
+	}
+	return c
 }
 
 // Describe sends the super-set of all possible descriptors of NGINX metrics
@@ -42,6 +48,18 @@ func (c *NginxCollector) Describe(ch chan<- *prometheus.Desc) {
 
 	for _, m := range c.metrics {
 		ch <- m
+	}
+}
+
+func (c *NginxCollector) newGaugeMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, value float64, labelValues ...string) {
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, labelValues...)
+}
+
+func (c *NginxCollector) newCounterMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, value float64, labelValues ...string) {
+	if c.createdAt.IsZero() {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, value, labelValues...)
+	} else {
+		ch <- prometheus.MustNewConstMetricWithCreatedTimestamp(desc, prometheus.CounterValue, value, c.createdAt, labelValues...)
 	}
 }
 
@@ -61,18 +79,18 @@ func (c *NginxCollector) Collect(ch chan<- prometheus.Metric) {
 	c.upMetric.Set(nginxUp)
 	ch <- c.upMetric
 
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_active"],
-		prometheus.GaugeValue, float64(stats.Connections.Active))
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_accepted"],
-		prometheus.CounterValue, float64(stats.Connections.Accepted))
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_handled"],
-		prometheus.CounterValue, float64(stats.Connections.Handled))
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_reading"],
-		prometheus.GaugeValue, float64(stats.Connections.Reading))
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_writing"],
-		prometheus.GaugeValue, float64(stats.Connections.Writing))
-	ch <- prometheus.MustNewConstMetric(c.metrics["connections_waiting"],
-		prometheus.GaugeValue, float64(stats.Connections.Waiting))
-	ch <- prometheus.MustNewConstMetric(c.metrics["http_requests_total"],
-		prometheus.CounterValue, float64(stats.Requests))
+	c.newGaugeMetric(ch, c.metrics["connections_active"],
+		float64(stats.Connections.Active))
+	c.newCounterMetric(ch, c.metrics["connections_accepted"],
+		float64(stats.Connections.Accepted))
+	c.newCounterMetric(ch, c.metrics["connections_handled"],
+		float64(stats.Connections.Handled))
+	c.newGaugeMetric(ch, c.metrics["connections_reading"],
+		float64(stats.Connections.Reading))
+	c.newGaugeMetric(ch, c.metrics["connections_writing"],
+		float64(stats.Connections.Writing))
+	c.newGaugeMetric(ch, c.metrics["connections_waiting"],
+		float64(stats.Connections.Waiting))
+	c.newCounterMetric(ch, c.metrics["http_requests_total"],
+		float64(stats.Requests))
 }

--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync"
+	"time"
 
 	plusclient "github.com/nginx/nginx-plus-go-client/v3/client"
 	"github.com/prometheus/client_golang/prometheus"
@@ -59,6 +60,7 @@ type NginxPlusCollector struct {
 	variableLabelNames             VariableLabelNames
 	variableLabelsMutex            sync.RWMutex
 	mutex                          sync.Mutex
+	createdAtFunc                  func(*plusclient.Stats) time.Time
 }
 
 // UpdateUpstreamServerPeerLabels updates the Upstream Server Peer Labels.
@@ -256,13 +258,13 @@ func NewVariableLabelNames(upstreamServerVariableLabelNames []string, serverZone
 }
 
 // NewNginxPlusCollector creates an NginxPlusCollector.
-func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string, variableLabelNames VariableLabelNames, constLabels map[string]string, logger *slog.Logger) *NginxPlusCollector {
+func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string, variableLabelNames VariableLabelNames, constLabels map[string]string, logger *slog.Logger, ctSource CTSource) *NginxPlusCollector {
 	upstreamServerVariableLabelNames := variableLabelNames.UpstreamServerVariableLabelNames
 	streamUpstreamServerVariableLabelNames := variableLabelNames.StreamUpstreamServerVariableLabelNames
 
 	upstreamServerVariableLabelNames = append(upstreamServerVariableLabelNames, variableLabelNames.UpstreamServerPeerVariableLabelNames...)
 	streamUpstreamServerVariableLabelNames = append(streamUpstreamServerVariableLabelNames, variableLabelNames.StreamUpstreamServerPeerVariableLabelNames...)
-	return &NginxPlusCollector{
+	c := &NginxPlusCollector{
 		variableLabelNames:             variableLabelNames,
 		upstreamServerLabels:           make(map[string][]string),
 		serverZoneLabels:               make(map[string][]string),
@@ -568,6 +570,20 @@ func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string
 			"http_requests_current": newWorkerMetric(namespace, "http_requests_current", "The current number of client requests that are currently being processed by the worker process", constLabels),
 		},
 	}
+	if ctSource == CTSourceProcess {
+		now := nowFunc()
+		c.createdAtFunc = func(_ *plusclient.Stats) time.Time { return now }
+	} else if ctSource == CTSourceStats {
+		c.createdAtFunc = func(stats *plusclient.Stats) time.Time {
+			parsed, err := time.Parse(time.RFC3339Nano, stats.NginxInfo.LoadTimestamp)
+			if err != nil {
+				c.logger.Warn("error parsing load_timestamp for created timestamp", "load_timestamp", stats.NginxInfo.LoadTimestamp, "error", err.Error())
+				return time.Time{}
+			}
+			return parsed
+		}
+	}
+	return c
 }
 
 // Describe sends the super-set of all possible descriptors of NGINX Plus metrics
@@ -622,6 +638,18 @@ func (c *NginxPlusCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
+func (c *NginxPlusCollector) newCounterMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, createdAt time.Time, value float64, labelValues ...string) {
+	if createdAt.IsZero() {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, value, labelValues...)
+	} else {
+		ch <- prometheus.MustNewConstMetricWithCreatedTimestamp(desc, prometheus.CounterValue, value, createdAt, labelValues...)
+	}
+}
+
+func (c *NginxPlusCollector) newGaugeMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, value float64, labelValues ...string) {
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, labelValues...)
+}
+
 // Collect fetches metrics from NGINX Plus and sends them to the provided channel.
 func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 	c.mutex.Lock() // To protect metrics from concurrent collects
@@ -639,45 +667,47 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 	c.upMetric.Set(nginxUp)
 	ch <- c.upMetric
 
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["connections_accepted"],
-		prometheus.CounterValue, float64(stats.Connections.Accepted))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["connections_dropped"],
-		prometheus.CounterValue, float64(stats.Connections.Dropped))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["connections_active"],
-		prometheus.GaugeValue, float64(stats.Connections.Active))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["connections_idle"],
-		prometheus.GaugeValue, float64(stats.Connections.Idle))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["http_requests_total"],
-		prometheus.CounterValue, float64(stats.HTTPRequests.Total))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["http_requests_current"],
-		prometheus.GaugeValue, float64(stats.HTTPRequests.Current))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["ssl_handshakes"],
-		prometheus.CounterValue, float64(stats.SSL.Handshakes))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["ssl_handshakes_failed"],
-		prometheus.CounterValue, float64(stats.SSL.HandshakesFailed))
-	ch <- prometheus.MustNewConstMetric(c.totalMetrics["ssl_session_reuses"],
-		prometheus.CounterValue, float64(stats.SSL.SessionReuses))
+	createdAt := c.createdAtFunc(stats)
+
+	c.newCounterMetric(ch, c.totalMetrics["connections_accepted"], createdAt,
+		float64(stats.Connections.Accepted))
+	c.newCounterMetric(ch, c.totalMetrics["connections_dropped"], createdAt,
+		float64(stats.Connections.Dropped))
+	c.newGaugeMetric(ch, c.totalMetrics["connections_active"],
+		float64(stats.Connections.Active))
+	c.newGaugeMetric(ch, c.totalMetrics["connections_idle"],
+		float64(stats.Connections.Idle))
+	c.newCounterMetric(ch, c.totalMetrics["http_requests_total"], createdAt,
+		float64(stats.HTTPRequests.Total))
+	c.newGaugeMetric(ch, c.totalMetrics["http_requests_current"],
+		float64(stats.HTTPRequests.Current))
+	c.newCounterMetric(ch, c.totalMetrics["ssl_handshakes"], createdAt,
+		float64(stats.SSL.Handshakes))
+	c.newCounterMetric(ch, c.totalMetrics["ssl_handshakes_failed"], createdAt,
+		float64(stats.SSL.HandshakesFailed))
+	c.newCounterMetric(ch, c.totalMetrics["ssl_session_reuses"], createdAt,
+		float64(stats.SSL.SessionReuses))
 
 	license, err := c.nginxClient.GetNginxLicense(context.TODO())
 	if err != nil {
 		c.logger.Warn("error getting license information", "error", err.Error())
 	} else {
-		ch <- prometheus.MustNewConstMetric(c.totalMetrics["license_active_till"],
-			prometheus.GaugeValue, float64(license.ActiveTill))
+		c.newGaugeMetric(ch, c.totalMetrics["license_active_till"],
+			float64(license.ActiveTill))
 
 		if license.Reporting != nil {
 			if license.Reporting.Healthy {
-				ch <- prometheus.MustNewConstMetric(c.totalMetrics["license_reporting_healthy"],
-					prometheus.GaugeValue, float64(1))
+				c.newGaugeMetric(ch, c.totalMetrics["license_reporting_healthy"],
+					float64(1))
 			} else {
-				ch <- prometheus.MustNewConstMetric(c.totalMetrics["license_reporting_healthy"],
-					prometheus.GaugeValue, float64(0))
+				c.newGaugeMetric(ch, c.totalMetrics["license_reporting_healthy"],
+					float64(0))
 			}
-			ch <- prometheus.MustNewConstMetric(c.totalMetrics["license_reporting_fails"],
-				prometheus.GaugeValue, float64(license.Reporting.Fails))
+			c.newGaugeMetric(ch, c.totalMetrics["license_reporting_fails"],
+				float64(license.Reporting.Fails))
 
-			ch <- prometheus.MustNewConstMetric(c.totalMetrics["license_reporting_grace_period"],
-				prometheus.GaugeValue, float64(license.Reporting.Grace))
+			c.newGaugeMetric(ch, c.totalMetrics["license_reporting_grace_period"],
+				float64(license.Reporting.Grace))
 		}
 	}
 
@@ -694,112 +724,112 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 			labelValues = append(labelValues, varLabelValues...)
 		}
 
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["processing"],
-			prometheus.GaugeValue, float64(zone.Processing), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["requests"],
-			prometheus.CounterValue, float64(zone.Requests), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["responses_1xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses1xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["responses_2xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses2xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["responses_3xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses3xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["responses_4xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses4xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["responses_5xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses5xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["discarded"],
-			prometheus.CounterValue, float64(zone.Discarded), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["received"],
-			prometheus.CounterValue, float64(zone.Received), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["sent"],
-			prometheus.CounterValue, float64(zone.Sent), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_100"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPContinue), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_101"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSwitchingProtocols), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_102"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPProcessing), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_200"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPOk), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_201"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPCreated), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_202"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPAccepted), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_204"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNoContent), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_206"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPPartialContent), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_300"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSpecialResponse), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_301"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPMovedPermanently), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_302"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPMovedTemporarily), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_303"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSeeOther), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_304"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotModified), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_307"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPTemporaryRedirect), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_400"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPBadRequest), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_401"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPUnauthorized), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_403"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPForbidden), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_404"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotFound), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_405"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotAllowed), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_408"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestTimeOut), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_409"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPConflict), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_411"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPLengthRequired), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_412"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPPreconditionFailed), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_413"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestEntityTooLarge), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_414"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestURITooLarge), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_415"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPUnsupportedMediaType), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_416"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRangeNotSatisfiable), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_429"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPTooManyRequests), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_444"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPClose), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_494"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestHeaderTooLarge), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_495"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSCertError), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_496"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSNoCert), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_497"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPToHTTPS), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_499"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPClientClosedRequest), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_500"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPInternalServerError), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_501"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotImplemented), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_502"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPBadGateway), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_503"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPServiceUnavailable), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_504"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPGatewayTimeOut), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["codes_507"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPInsufficientStorage), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["ssl_handshakes"],
-			prometheus.CounterValue, float64(zone.SSL.Handshakes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["ssl_handshakes_failed"],
-			prometheus.CounterValue, float64(zone.SSL.HandshakesFailed), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.serverZoneMetrics["ssl_session_reuses"],
-			prometheus.CounterValue, float64(zone.SSL.SessionReuses), labelValues...)
+		c.newGaugeMetric(ch, c.serverZoneMetrics["processing"],
+			float64(zone.Processing), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["requests"], createdAt,
+			float64(zone.Requests), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["responses_1xx"], createdAt,
+			float64(zone.Responses.Responses1xx), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["responses_2xx"], createdAt,
+			float64(zone.Responses.Responses2xx), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["responses_3xx"], createdAt,
+			float64(zone.Responses.Responses3xx), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["responses_4xx"], createdAt,
+			float64(zone.Responses.Responses4xx), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["responses_5xx"], createdAt,
+			float64(zone.Responses.Responses5xx), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["discarded"], createdAt,
+			float64(zone.Discarded), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["received"], createdAt,
+			float64(zone.Received), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["sent"], createdAt,
+			float64(zone.Sent), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_100"], createdAt,
+			float64(zone.Responses.Codes.HTTPContinue), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_101"], createdAt,
+			float64(zone.Responses.Codes.HTTPSwitchingProtocols), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_102"], createdAt,
+			float64(zone.Responses.Codes.HTTPProcessing), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_200"], createdAt,
+			float64(zone.Responses.Codes.HTTPOk), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_201"], createdAt,
+			float64(zone.Responses.Codes.HTTPCreated), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_202"], createdAt,
+			float64(zone.Responses.Codes.HTTPAccepted), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_204"], createdAt,
+			float64(zone.Responses.Codes.HTTPNoContent), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_206"], createdAt,
+			float64(zone.Responses.Codes.HTTPPartialContent), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_300"], createdAt,
+			float64(zone.Responses.Codes.HTTPSpecialResponse), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_301"], createdAt,
+			float64(zone.Responses.Codes.HTTPMovedPermanently), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_302"], createdAt,
+			float64(zone.Responses.Codes.HTTPMovedTemporarily), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_303"], createdAt,
+			float64(zone.Responses.Codes.HTTPSeeOther), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_304"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotModified), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_307"], createdAt,
+			float64(zone.Responses.Codes.HTTPTemporaryRedirect), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_400"], createdAt,
+			float64(zone.Responses.Codes.HTTPBadRequest), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_401"], createdAt,
+			float64(zone.Responses.Codes.HTTPUnauthorized), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_403"], createdAt,
+			float64(zone.Responses.Codes.HTTPForbidden), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_404"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotFound), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_405"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotAllowed), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_408"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestTimeOut), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_409"], createdAt,
+			float64(zone.Responses.Codes.HTTPConflict), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_411"], createdAt,
+			float64(zone.Responses.Codes.HTTPLengthRequired), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_412"], createdAt,
+			float64(zone.Responses.Codes.HTTPPreconditionFailed), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_413"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestEntityTooLarge), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_414"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestURITooLarge), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_415"], createdAt,
+			float64(zone.Responses.Codes.HTTPUnsupportedMediaType), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_416"], createdAt,
+			float64(zone.Responses.Codes.HTTPRangeNotSatisfiable), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_429"], createdAt,
+			float64(zone.Responses.Codes.HTTPTooManyRequests), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_444"], createdAt,
+			float64(zone.Responses.Codes.HTTPClose), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_494"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestHeaderTooLarge), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_495"], createdAt,
+			float64(zone.Responses.Codes.HTTPSCertError), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_496"], createdAt,
+			float64(zone.Responses.Codes.HTTPSNoCert), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_497"], createdAt,
+			float64(zone.Responses.Codes.HTTPToHTTPS), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_499"], createdAt,
+			float64(zone.Responses.Codes.HTTPClientClosedRequest), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_500"], createdAt,
+			float64(zone.Responses.Codes.HTTPInternalServerError), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_501"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotImplemented), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_502"], createdAt,
+			float64(zone.Responses.Codes.HTTPBadGateway), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_503"], createdAt,
+			float64(zone.Responses.Codes.HTTPServiceUnavailable), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_504"], createdAt,
+			float64(zone.Responses.Codes.HTTPGatewayTimeOut), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["codes_507"], createdAt,
+			float64(zone.Responses.Codes.HTTPInsufficientStorage), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["ssl_handshakes"], createdAt,
+			float64(zone.SSL.Handshakes), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["ssl_handshakes_failed"], createdAt,
+			float64(zone.SSL.HandshakesFailed), labelValues...)
+		c.newCounterMetric(ch, c.serverZoneMetrics["ssl_session_reuses"], createdAt,
+			float64(zone.SSL.SessionReuses), labelValues...)
 	}
 
 	for name, zone := range stats.StreamServerZones {
@@ -814,28 +844,28 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 		} else {
 			labelValues = append(labelValues, varLabelValues...)
 		}
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["processing"],
-			prometheus.GaugeValue, float64(zone.Processing), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["connections"],
-			prometheus.CounterValue, float64(zone.Connections), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_2xx"],
-			prometheus.CounterValue, float64(zone.Sessions.Sessions2xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_4xx"],
-			prometheus.CounterValue, float64(zone.Sessions.Sessions4xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_5xx"],
-			prometheus.CounterValue, float64(zone.Sessions.Sessions5xx), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["discarded"],
-			prometheus.CounterValue, float64(zone.Discarded), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["received"],
-			prometheus.CounterValue, float64(zone.Received), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sent"],
-			prometheus.CounterValue, float64(zone.Sent), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["ssl_handshakes"],
-			prometheus.CounterValue, float64(zone.SSL.Handshakes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["ssl_handshakes_failed"],
-			prometheus.CounterValue, float64(zone.SSL.HandshakesFailed), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["ssl_session_reuses"],
-			prometheus.CounterValue, float64(zone.SSL.SessionReuses), labelValues...)
+		c.newGaugeMetric(ch, c.streamServerZoneMetrics["processing"],
+			float64(zone.Processing), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["connections"], createdAt,
+			float64(zone.Connections), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["sessions_2xx"], createdAt,
+			float64(zone.Sessions.Sessions2xx), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["sessions_4xx"], createdAt,
+			float64(zone.Sessions.Sessions4xx), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["sessions_5xx"], createdAt,
+			float64(zone.Sessions.Sessions5xx), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["discarded"], createdAt,
+			float64(zone.Discarded), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["received"], createdAt,
+			float64(zone.Received), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["sent"], createdAt,
+			float64(zone.Sent), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["ssl_handshakes"], createdAt,
+			float64(zone.SSL.Handshakes), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["ssl_handshakes_failed"], createdAt,
+			float64(zone.SSL.HandshakesFailed), labelValues...)
+		c.newCounterMetric(ch, c.streamServerZoneMetrics["ssl_session_reuses"], createdAt,
+			float64(zone.SSL.SessionReuses), labelValues...)
 	}
 
 	for name, upstream := range stats.Upstreams {
@@ -863,136 +893,136 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 				labelValues = append(labelValues, varPeerLabelValues...)
 			}
 
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["state"],
-				prometheus.GaugeValue, upstreamServerStates[peer.State], labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["active"],
-				prometheus.GaugeValue, float64(peer.Active), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["limit"],
-				prometheus.GaugeValue, float64(peer.MaxConns), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["requests"],
-				prometheus.CounterValue, float64(peer.Requests), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["responses_1xx"],
-				prometheus.CounterValue, float64(peer.Responses.Responses1xx), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["responses_2xx"],
-				prometheus.CounterValue, float64(peer.Responses.Responses2xx), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["responses_3xx"],
-				prometheus.CounterValue, float64(peer.Responses.Responses3xx), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["responses_4xx"],
-				prometheus.CounterValue, float64(peer.Responses.Responses4xx), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["responses_5xx"],
-				prometheus.CounterValue, float64(peer.Responses.Responses5xx), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["sent"],
-				prometheus.CounterValue, float64(peer.Sent), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["received"],
-				prometheus.CounterValue, float64(peer.Received), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["fails"],
-				prometheus.CounterValue, float64(peer.Fails), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["unavail"],
-				prometheus.CounterValue, float64(peer.Unavail), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["header_time"],
-				prometheus.GaugeValue, float64(peer.HeaderTime), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["response_time"],
-				prometheus.GaugeValue, float64(peer.ResponseTime), labelValues...)
+			c.newGaugeMetric(ch, c.upstreamServerMetrics["state"],
+				upstreamServerStates[peer.State], labelValues...)
+			c.newGaugeMetric(ch, c.upstreamServerMetrics["active"],
+				float64(peer.Active), labelValues...)
+			c.newGaugeMetric(ch, c.upstreamServerMetrics["limit"],
+				float64(peer.MaxConns), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["requests"], createdAt,
+				float64(peer.Requests), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["responses_1xx"], createdAt,
+				float64(peer.Responses.Responses1xx), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["responses_2xx"], createdAt,
+				float64(peer.Responses.Responses2xx), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["responses_3xx"], createdAt,
+				float64(peer.Responses.Responses3xx), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["responses_4xx"], createdAt,
+				float64(peer.Responses.Responses4xx), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["responses_5xx"], createdAt,
+				float64(peer.Responses.Responses5xx), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["sent"], createdAt,
+				float64(peer.Sent), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["received"], createdAt,
+				float64(peer.Received), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["fails"], createdAt,
+				float64(peer.Fails), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["unavail"], createdAt,
+				float64(peer.Unavail), labelValues...)
+			c.newGaugeMetric(ch, c.upstreamServerMetrics["header_time"],
+				float64(peer.HeaderTime), labelValues...)
+			c.newGaugeMetric(ch, c.upstreamServerMetrics["response_time"],
+				float64(peer.ResponseTime), labelValues...)
 
 			if peer.HealthChecks != (plusclient.HealthChecks{}) {
-				ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["health_checks_checks"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Checks), labelValues...)
-				ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["health_checks_fails"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Fails), labelValues...)
-				ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["health_checks_unhealthy"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Unhealthy), labelValues...)
+				c.newCounterMetric(ch, c.upstreamServerMetrics["health_checks_checks"], createdAt,
+					float64(peer.HealthChecks.Checks), labelValues...)
+				c.newCounterMetric(ch, c.upstreamServerMetrics["health_checks_fails"], createdAt,
+					float64(peer.HealthChecks.Fails), labelValues...)
+				c.newCounterMetric(ch, c.upstreamServerMetrics["health_checks_unhealthy"], createdAt,
+					float64(peer.HealthChecks.Unhealthy), labelValues...)
 			}
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_100"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPContinue), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_101"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPSwitchingProtocols), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_102"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPProcessing), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_200"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPOk), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_201"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPCreated), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_202"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPAccepted), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_204"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPNoContent), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_206"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPPartialContent), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_300"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPSpecialResponse), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_301"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPMovedPermanently), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_302"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPMovedTemporarily), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_303"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPSeeOther), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_304"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPNotModified), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_307"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPTemporaryRedirect), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_400"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPBadRequest), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_401"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPUnauthorized), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_403"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPForbidden), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_404"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPNotFound), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_405"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPNotAllowed), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_408"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPRequestTimeOut), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_409"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPConflict), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_411"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPLengthRequired), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_412"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPPreconditionFailed), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_413"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPRequestEntityTooLarge), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_414"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPRequestURITooLarge), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_415"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPUnsupportedMediaType), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_416"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPRangeNotSatisfiable), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_429"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPTooManyRequests), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_444"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPClose), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_494"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPRequestHeaderTooLarge), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_495"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPSCertError), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_496"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPSNoCert), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_497"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPToHTTPS), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_499"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPClientClosedRequest), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_500"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPInternalServerError), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_501"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPNotImplemented), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_502"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPBadGateway), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_503"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPServiceUnavailable), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_504"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPGatewayTimeOut), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["codes_507"],
-				prometheus.CounterValue, float64(peer.Responses.Codes.HTTPInsufficientStorage), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["ssl_handshakes"],
-				prometheus.CounterValue, float64(peer.SSL.Handshakes), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["ssl_handshakes_failed"],
-				prometheus.CounterValue, float64(peer.SSL.HandshakesFailed), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["ssl_session_reuses"],
-				prometheus.CounterValue, float64(peer.SSL.SessionReuses), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_100"], createdAt,
+				float64(peer.Responses.Codes.HTTPContinue), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_101"], createdAt,
+				float64(peer.Responses.Codes.HTTPSwitchingProtocols), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_102"], createdAt,
+				float64(peer.Responses.Codes.HTTPProcessing), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_200"], createdAt,
+				float64(peer.Responses.Codes.HTTPOk), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_201"], createdAt,
+				float64(peer.Responses.Codes.HTTPCreated), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_202"], createdAt,
+				float64(peer.Responses.Codes.HTTPAccepted), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_204"], createdAt,
+				float64(peer.Responses.Codes.HTTPNoContent), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_206"], createdAt,
+				float64(peer.Responses.Codes.HTTPPartialContent), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_300"], createdAt,
+				float64(peer.Responses.Codes.HTTPSpecialResponse), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_301"], createdAt,
+				float64(peer.Responses.Codes.HTTPMovedPermanently), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_302"], createdAt,
+				float64(peer.Responses.Codes.HTTPMovedTemporarily), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_303"], createdAt,
+				float64(peer.Responses.Codes.HTTPSeeOther), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_304"], createdAt,
+				float64(peer.Responses.Codes.HTTPNotModified), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_307"], createdAt,
+				float64(peer.Responses.Codes.HTTPTemporaryRedirect), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_400"], createdAt,
+				float64(peer.Responses.Codes.HTTPBadRequest), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_401"], createdAt,
+				float64(peer.Responses.Codes.HTTPUnauthorized), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_403"], createdAt,
+				float64(peer.Responses.Codes.HTTPForbidden), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_404"], createdAt,
+				float64(peer.Responses.Codes.HTTPNotFound), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_405"], createdAt,
+				float64(peer.Responses.Codes.HTTPNotAllowed), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_408"], createdAt,
+				float64(peer.Responses.Codes.HTTPRequestTimeOut), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_409"], createdAt,
+				float64(peer.Responses.Codes.HTTPConflict), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_411"], createdAt,
+				float64(peer.Responses.Codes.HTTPLengthRequired), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_412"], createdAt,
+				float64(peer.Responses.Codes.HTTPPreconditionFailed), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_413"], createdAt,
+				float64(peer.Responses.Codes.HTTPRequestEntityTooLarge), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_414"], createdAt,
+				float64(peer.Responses.Codes.HTTPRequestURITooLarge), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_415"], createdAt,
+				float64(peer.Responses.Codes.HTTPUnsupportedMediaType), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_416"], createdAt,
+				float64(peer.Responses.Codes.HTTPRangeNotSatisfiable), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_429"], createdAt,
+				float64(peer.Responses.Codes.HTTPTooManyRequests), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_444"], createdAt,
+				float64(peer.Responses.Codes.HTTPClose), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_494"], createdAt,
+				float64(peer.Responses.Codes.HTTPRequestHeaderTooLarge), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_495"], createdAt,
+				float64(peer.Responses.Codes.HTTPSCertError), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_496"], createdAt,
+				float64(peer.Responses.Codes.HTTPSNoCert), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_497"], createdAt,
+				float64(peer.Responses.Codes.HTTPToHTTPS), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_499"], createdAt,
+				float64(peer.Responses.Codes.HTTPClientClosedRequest), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_500"], createdAt,
+				float64(peer.Responses.Codes.HTTPInternalServerError), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_501"], createdAt,
+				float64(peer.Responses.Codes.HTTPNotImplemented), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_502"], createdAt,
+				float64(peer.Responses.Codes.HTTPBadGateway), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_503"], createdAt,
+				float64(peer.Responses.Codes.HTTPServiceUnavailable), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_504"], createdAt,
+				float64(peer.Responses.Codes.HTTPGatewayTimeOut), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["codes_507"], createdAt,
+				float64(peer.Responses.Codes.HTTPInsufficientStorage), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["ssl_handshakes"], createdAt,
+				float64(peer.SSL.Handshakes), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["ssl_handshakes_failed"], createdAt,
+				float64(peer.SSL.HandshakesFailed), labelValues...)
+			c.newCounterMetric(ch, c.upstreamServerMetrics["ssl_session_reuses"], createdAt,
+				float64(peer.SSL.SessionReuses), labelValues...)
 		}
-		ch <- prometheus.MustNewConstMetric(c.upstreamMetrics["keepalive"],
-			prometheus.GaugeValue, float64(upstream.Keepalive), name)
-		ch <- prometheus.MustNewConstMetric(c.upstreamMetrics["zombies"],
-			prometheus.GaugeValue, float64(upstream.Zombies), name)
+		c.newGaugeMetric(ch, c.upstreamMetrics["keepalive"],
+			float64(upstream.Keepalive), name)
+		c.newGaugeMetric(ch, c.upstreamMetrics["zombies"],
+			float64(upstream.Zombies), name)
 	}
 
 	for name, upstream := range stats.StreamUpstreams {
@@ -1020,211 +1050,211 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 				labelValues = append(labelValues, varPeerLabelValues...)
 			}
 
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["state"],
-				prometheus.GaugeValue, upstreamServerStates[peer.State], labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["active"],
-				prometheus.GaugeValue, float64(peer.Active), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["limit"],
-				prometheus.GaugeValue, float64(peer.MaxConns), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["connections"],
-				prometheus.CounterValue, float64(peer.Connections), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["connect_time"],
-				prometheus.GaugeValue, float64(peer.ConnectTime), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["first_byte_time"],
-				prometheus.GaugeValue, float64(peer.FirstByteTime), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["response_time"],
-				prometheus.GaugeValue, float64(peer.ResponseTime), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["sent"],
-				prometheus.CounterValue, float64(peer.Sent), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["received"],
-				prometheus.CounterValue, float64(peer.Received), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["fails"],
-				prometheus.CounterValue, float64(peer.Fails), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["unavail"],
-				prometheus.CounterValue, float64(peer.Unavail), labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["state"],
+				upstreamServerStates[peer.State], labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["active"],
+				float64(peer.Active), labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["limit"],
+				float64(peer.MaxConns), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["connections"], createdAt,
+				float64(peer.Connections), labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["connect_time"],
+				float64(peer.ConnectTime), labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["first_byte_time"],
+				float64(peer.FirstByteTime), labelValues...)
+			c.newGaugeMetric(ch, c.streamUpstreamServerMetrics["response_time"],
+				float64(peer.ResponseTime), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["sent"], createdAt,
+				float64(peer.Sent), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["received"], createdAt,
+				float64(peer.Received), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["fails"], createdAt,
+				float64(peer.Fails), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["unavail"], createdAt,
+				float64(peer.Unavail), labelValues...)
 			if peer.HealthChecks != (plusclient.HealthChecks{}) {
-				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_checks"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Checks), labelValues...)
-				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_fails"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Fails), labelValues...)
-				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_unhealthy"],
-					prometheus.CounterValue, float64(peer.HealthChecks.Unhealthy), labelValues...)
+				c.newCounterMetric(ch, c.streamUpstreamServerMetrics["health_checks_checks"], createdAt,
+					float64(peer.HealthChecks.Checks), labelValues...)
+				c.newCounterMetric(ch, c.streamUpstreamServerMetrics["health_checks_fails"], createdAt,
+					float64(peer.HealthChecks.Fails), labelValues...)
+				c.newCounterMetric(ch, c.streamUpstreamServerMetrics["health_checks_unhealthy"], createdAt,
+					float64(peer.HealthChecks.Unhealthy), labelValues...)
 			}
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["ssl_handshakes"],
-				prometheus.CounterValue, float64(peer.SSL.Handshakes), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["ssl_handshakes_failed"],
-				prometheus.CounterValue, float64(peer.SSL.HandshakesFailed), labelValues...)
-			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["ssl_session_reuses"],
-				prometheus.CounterValue, float64(peer.SSL.SessionReuses), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["ssl_handshakes"], createdAt,
+				float64(peer.SSL.Handshakes), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["ssl_handshakes_failed"], createdAt,
+				float64(peer.SSL.HandshakesFailed), labelValues...)
+			c.newCounterMetric(ch, c.streamUpstreamServerMetrics["ssl_session_reuses"], createdAt,
+				float64(peer.SSL.SessionReuses), labelValues...)
 		}
-		ch <- prometheus.MustNewConstMetric(c.streamUpstreamMetrics["zombies"],
-			prometheus.GaugeValue, float64(upstream.Zombies), name)
+		c.newGaugeMetric(ch, c.streamUpstreamMetrics["zombies"],
+			float64(upstream.Zombies), name)
 	}
 
 	if stats.StreamZoneSync != nil {
 		for name, zone := range stats.StreamZoneSync.Zones {
-			ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_pending"],
-				prometheus.GaugeValue, float64(zone.RecordsPending), name)
-			ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_total"],
-				prometheus.GaugeValue, float64(zone.RecordsTotal), name)
+			c.newGaugeMetric(ch, c.streamZoneSyncMetrics["records_pending"],
+				float64(zone.RecordsPending), name)
+			c.newGaugeMetric(ch, c.streamZoneSyncMetrics["records_total"],
+				float64(zone.RecordsTotal), name)
 		}
 
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_in"],
-			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesIn))
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_out"],
-			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesOut))
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_in"],
-			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsIn))
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_out"],
-			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsOut))
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["nodes_online"],
-			prometheus.GaugeValue, float64(stats.StreamZoneSync.Status.NodesOnline))
+		c.newCounterMetric(ch, c.streamZoneSyncMetrics["bytes_in"], createdAt,
+			float64(stats.StreamZoneSync.Status.BytesIn))
+		c.newCounterMetric(ch, c.streamZoneSyncMetrics["bytes_out"], createdAt,
+			float64(stats.StreamZoneSync.Status.BytesOut))
+		c.newCounterMetric(ch, c.streamZoneSyncMetrics["msgs_in"], createdAt,
+			float64(stats.StreamZoneSync.Status.MsgsIn))
+		c.newCounterMetric(ch, c.streamZoneSyncMetrics["msgs_out"], createdAt,
+			float64(stats.StreamZoneSync.Status.MsgsOut))
+		c.newGaugeMetric(ch, c.streamZoneSyncMetrics["nodes_online"],
+			float64(stats.StreamZoneSync.Status.NodesOnline))
 	}
 
 	for name, zone := range stats.LocationZones {
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["requests"],
-			prometheus.CounterValue, float64(zone.Requests), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["responses_1xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses1xx), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["responses_2xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses2xx), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["responses_3xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses3xx), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["responses_4xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses4xx), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["responses_5xx"],
-			prometheus.CounterValue, float64(zone.Responses.Responses5xx), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["discarded"],
-			prometheus.CounterValue, float64(zone.Discarded), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["received"],
-			prometheus.CounterValue, float64(zone.Received), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["sent"],
-			prometheus.CounterValue, float64(zone.Sent), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_100"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPContinue), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_101"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSwitchingProtocols), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_102"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPProcessing), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_200"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPOk), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_201"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPCreated), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_202"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPAccepted), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_204"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNoContent), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_206"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPPartialContent), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_300"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSpecialResponse), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_301"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPMovedPermanently), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_302"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPMovedTemporarily), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_303"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSeeOther), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_304"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotModified), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_307"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPTemporaryRedirect), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_400"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPBadRequest), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_401"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPUnauthorized), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_403"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPForbidden), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_404"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotFound), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_405"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotAllowed), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_408"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestTimeOut), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_409"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPConflict), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_411"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPLengthRequired), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_412"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPPreconditionFailed), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_413"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestEntityTooLarge), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_414"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestURITooLarge), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_415"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPUnsupportedMediaType), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_416"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRangeNotSatisfiable), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_429"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPTooManyRequests), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_444"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPClose), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_494"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPRequestHeaderTooLarge), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_495"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSCertError), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_496"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPSNoCert), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_497"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPToHTTPS), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_499"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPClientClosedRequest), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_500"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPInternalServerError), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_501"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPNotImplemented), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_502"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPBadGateway), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_503"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPServiceUnavailable), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_504"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPGatewayTimeOut), name)
-		ch <- prometheus.MustNewConstMetric(c.locationZoneMetrics["codes_507"],
-			prometheus.CounterValue, float64(zone.Responses.Codes.HTTPInsufficientStorage), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["requests"], createdAt,
+			float64(zone.Requests), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["responses_1xx"], createdAt,
+			float64(zone.Responses.Responses1xx), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["responses_2xx"], createdAt,
+			float64(zone.Responses.Responses2xx), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["responses_3xx"], createdAt,
+			float64(zone.Responses.Responses3xx), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["responses_4xx"], createdAt,
+			float64(zone.Responses.Responses4xx), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["responses_5xx"], createdAt,
+			float64(zone.Responses.Responses5xx), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["discarded"], createdAt,
+			float64(zone.Discarded), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["received"], createdAt,
+			float64(zone.Received), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["sent"], createdAt,
+			float64(zone.Sent), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_100"], createdAt,
+			float64(zone.Responses.Codes.HTTPContinue), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_101"], createdAt,
+			float64(zone.Responses.Codes.HTTPSwitchingProtocols), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_102"], createdAt,
+			float64(zone.Responses.Codes.HTTPProcessing), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_200"], createdAt,
+			float64(zone.Responses.Codes.HTTPOk), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_201"], createdAt,
+			float64(zone.Responses.Codes.HTTPCreated), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_202"], createdAt,
+			float64(zone.Responses.Codes.HTTPAccepted), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_204"], createdAt,
+			float64(zone.Responses.Codes.HTTPNoContent), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_206"], createdAt,
+			float64(zone.Responses.Codes.HTTPPartialContent), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_300"], createdAt,
+			float64(zone.Responses.Codes.HTTPSpecialResponse), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_301"], createdAt,
+			float64(zone.Responses.Codes.HTTPMovedPermanently), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_302"], createdAt,
+			float64(zone.Responses.Codes.HTTPMovedTemporarily), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_303"], createdAt,
+			float64(zone.Responses.Codes.HTTPSeeOther), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_304"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotModified), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_307"], createdAt,
+			float64(zone.Responses.Codes.HTTPTemporaryRedirect), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_400"], createdAt,
+			float64(zone.Responses.Codes.HTTPBadRequest), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_401"], createdAt,
+			float64(zone.Responses.Codes.HTTPUnauthorized), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_403"], createdAt,
+			float64(zone.Responses.Codes.HTTPForbidden), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_404"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotFound), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_405"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotAllowed), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_408"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestTimeOut), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_409"], createdAt,
+			float64(zone.Responses.Codes.HTTPConflict), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_411"], createdAt,
+			float64(zone.Responses.Codes.HTTPLengthRequired), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_412"], createdAt,
+			float64(zone.Responses.Codes.HTTPPreconditionFailed), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_413"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestEntityTooLarge), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_414"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestURITooLarge), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_415"], createdAt,
+			float64(zone.Responses.Codes.HTTPUnsupportedMediaType), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_416"], createdAt,
+			float64(zone.Responses.Codes.HTTPRangeNotSatisfiable), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_429"], createdAt,
+			float64(zone.Responses.Codes.HTTPTooManyRequests), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_444"], createdAt,
+			float64(zone.Responses.Codes.HTTPClose), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_494"], createdAt,
+			float64(zone.Responses.Codes.HTTPRequestHeaderTooLarge), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_495"], createdAt,
+			float64(zone.Responses.Codes.HTTPSCertError), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_496"], createdAt,
+			float64(zone.Responses.Codes.HTTPSNoCert), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_497"], createdAt,
+			float64(zone.Responses.Codes.HTTPToHTTPS), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_499"], createdAt,
+			float64(zone.Responses.Codes.HTTPClientClosedRequest), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_500"], createdAt,
+			float64(zone.Responses.Codes.HTTPInternalServerError), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_501"], createdAt,
+			float64(zone.Responses.Codes.HTTPNotImplemented), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_502"], createdAt,
+			float64(zone.Responses.Codes.HTTPBadGateway), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_503"], createdAt,
+			float64(zone.Responses.Codes.HTTPServiceUnavailable), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_504"], createdAt,
+			float64(zone.Responses.Codes.HTTPGatewayTimeOut), name)
+		c.newCounterMetric(ch, c.locationZoneMetrics["codes_507"], createdAt,
+			float64(zone.Responses.Codes.HTTPInsufficientStorage), name)
 	}
 
 	for name, zone := range stats.Resolvers {
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["name"],
-			prometheus.CounterValue, float64(zone.Requests.Name), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["srv"],
-			prometheus.CounterValue, float64(zone.Requests.Srv), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["addr"],
-			prometheus.CounterValue, float64(zone.Requests.Addr), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["noerror"],
-			prometheus.CounterValue, float64(zone.Responses.Noerror), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["formerr"],
-			prometheus.CounterValue, float64(zone.Responses.Formerr), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["servfail"],
-			prometheus.CounterValue, float64(zone.Responses.Servfail), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["nxdomain"],
-			prometheus.CounterValue, float64(zone.Responses.Nxdomain), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["notimp"],
-			prometheus.CounterValue, float64(zone.Responses.Notimp), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["refused"],
-			prometheus.CounterValue, float64(zone.Responses.Refused), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["timedout"],
-			prometheus.CounterValue, float64(zone.Responses.Timedout), name)
-		ch <- prometheus.MustNewConstMetric(c.resolverMetrics["unknown"],
-			prometheus.CounterValue, float64(zone.Responses.Unknown), name)
+		c.newCounterMetric(ch, c.resolverMetrics["name"], createdAt,
+			float64(zone.Requests.Name), name)
+		c.newCounterMetric(ch, c.resolverMetrics["srv"], createdAt,
+			float64(zone.Requests.Srv), name)
+		c.newCounterMetric(ch, c.resolverMetrics["addr"], createdAt,
+			float64(zone.Requests.Addr), name)
+		c.newCounterMetric(ch, c.resolverMetrics["noerror"], createdAt,
+			float64(zone.Responses.Noerror), name)
+		c.newCounterMetric(ch, c.resolverMetrics["formerr"], createdAt,
+			float64(zone.Responses.Formerr), name)
+		c.newCounterMetric(ch, c.resolverMetrics["servfail"], createdAt,
+			float64(zone.Responses.Servfail), name)
+		c.newCounterMetric(ch, c.resolverMetrics["nxdomain"], createdAt,
+			float64(zone.Responses.Nxdomain), name)
+		c.newCounterMetric(ch, c.resolverMetrics["notimp"], createdAt,
+			float64(zone.Responses.Notimp), name)
+		c.newCounterMetric(ch, c.resolverMetrics["refused"], createdAt,
+			float64(zone.Responses.Refused), name)
+		c.newCounterMetric(ch, c.resolverMetrics["timedout"], createdAt,
+			float64(zone.Responses.Timedout), name)
+		c.newCounterMetric(ch, c.resolverMetrics["unknown"], createdAt,
+			float64(zone.Responses.Unknown), name)
 	}
 
 	for name, zone := range stats.HTTPLimitRequests {
-		ch <- prometheus.MustNewConstMetric(c.limitRequestMetrics["passed"], prometheus.CounterValue, float64(zone.Passed), name)
-		ch <- prometheus.MustNewConstMetric(c.limitRequestMetrics["rejected"], prometheus.CounterValue, float64(zone.Rejected), name)
-		ch <- prometheus.MustNewConstMetric(c.limitRequestMetrics["delayed"], prometheus.CounterValue, float64(zone.Delayed), name)
-		ch <- prometheus.MustNewConstMetric(c.limitRequestMetrics["rejected_dry_run"], prometheus.CounterValue, float64(zone.RejectedDryRun), name)
-		ch <- prometheus.MustNewConstMetric(c.limitRequestMetrics["delayed_dry_run"], prometheus.CounterValue, float64(zone.DelayedDryRun), name)
+		c.newCounterMetric(ch, c.limitRequestMetrics["passed"], createdAt, float64(zone.Passed), name)
+		c.newCounterMetric(ch, c.limitRequestMetrics["rejected"], createdAt, float64(zone.Rejected), name)
+		c.newCounterMetric(ch, c.limitRequestMetrics["delayed"], createdAt, float64(zone.Delayed), name)
+		c.newCounterMetric(ch, c.limitRequestMetrics["rejected_dry_run"], createdAt, float64(zone.RejectedDryRun), name)
+		c.newCounterMetric(ch, c.limitRequestMetrics["delayed_dry_run"], createdAt, float64(zone.DelayedDryRun), name)
 	}
 
 	for name, zone := range stats.HTTPLimitConnections {
-		ch <- prometheus.MustNewConstMetric(c.limitConnectionMetrics["passed"], prometheus.CounterValue, float64(zone.Passed), name)
-		ch <- prometheus.MustNewConstMetric(c.limitConnectionMetrics["rejected"], prometheus.CounterValue, float64(zone.Rejected), name)
-		ch <- prometheus.MustNewConstMetric(c.limitConnectionMetrics["rejected_dry_run"], prometheus.CounterValue, float64(zone.RejectedDryRun), name)
+		c.newCounterMetric(ch, c.limitConnectionMetrics["passed"], createdAt, float64(zone.Passed), name)
+		c.newCounterMetric(ch, c.limitConnectionMetrics["rejected"], createdAt, float64(zone.Rejected), name)
+		c.newCounterMetric(ch, c.limitConnectionMetrics["rejected_dry_run"], createdAt, float64(zone.RejectedDryRun), name)
 	}
 
 	for name, zone := range stats.StreamLimitConnections {
-		ch <- prometheus.MustNewConstMetric(c.streamLimitConnectionMetrics["passed"], prometheus.CounterValue, float64(zone.Passed), name)
-		ch <- prometheus.MustNewConstMetric(c.streamLimitConnectionMetrics["rejected"], prometheus.CounterValue, float64(zone.Rejected), name)
-		ch <- prometheus.MustNewConstMetric(c.streamLimitConnectionMetrics["rejected_dry_run"], prometheus.CounterValue, float64(zone.RejectedDryRun), name)
+		c.newCounterMetric(ch, c.streamLimitConnectionMetrics["passed"], createdAt, float64(zone.Passed), name)
+		c.newCounterMetric(ch, c.streamLimitConnectionMetrics["rejected"], createdAt, float64(zone.Rejected), name)
+		c.newCounterMetric(ch, c.streamLimitConnectionMetrics["rejected_dry_run"], createdAt, float64(zone.RejectedDryRun), name)
 	}
 
 	for name, zone := range stats.Caches {
@@ -1240,38 +1270,38 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 			labelValues = append(labelValues, varLabelValues...)
 		}
 
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["size"], prometheus.GaugeValue, float64(zone.Size), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["max_size"], prometheus.GaugeValue, float64(zone.MaxSize), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["cold"], prometheus.GaugeValue, booleanToFloat64[zone.Cold], labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["hit_responses"], prometheus.CounterValue, float64(zone.Hit.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["hit_bytes"], prometheus.CounterValue, float64(zone.Hit.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["stale_responses"], prometheus.CounterValue, float64(zone.Stale.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["stale_bytes"], prometheus.CounterValue, float64(zone.Stale.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["updating_responses"], prometheus.CounterValue, float64(zone.Updating.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["updating_bytes"], prometheus.CounterValue, float64(zone.Updating.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["revalidated_responses"], prometheus.CounterValue, float64(zone.Revalidated.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["revalidated_bytes"], prometheus.CounterValue, float64(zone.Revalidated.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["miss_responses"], prometheus.CounterValue, float64(zone.Miss.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["miss_bytes"], prometheus.CounterValue, float64(zone.Miss.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["expired_responses"], prometheus.CounterValue, float64(zone.Expired.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["expired_bytes"], prometheus.CounterValue, float64(zone.Expired.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["expired_responses_written"], prometheus.CounterValue, float64(zone.Expired.ResponsesWritten), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["expired_bytes_written"], prometheus.CounterValue, float64(zone.Expired.BytesWritten), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_responses"], prometheus.CounterValue, float64(zone.Bypass.Responses), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_bytes"], prometheus.CounterValue, float64(zone.Bypass.Bytes), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_responses_written"], prometheus.CounterValue, float64(zone.Bypass.ResponsesWritten), labelValues...)
-		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_bytes_written"], prometheus.CounterValue, float64(zone.Bypass.BytesWritten), labelValues...)
+		c.newGaugeMetric(ch, c.cacheZoneMetrics["size"], float64(zone.Size), labelValues...)
+		c.newGaugeMetric(ch, c.cacheZoneMetrics["max_size"], float64(zone.MaxSize), labelValues...)
+		c.newGaugeMetric(ch, c.cacheZoneMetrics["cold"], booleanToFloat64[zone.Cold], labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["hit_responses"], createdAt, float64(zone.Hit.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["hit_bytes"], createdAt, float64(zone.Hit.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["stale_responses"], createdAt, float64(zone.Stale.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["stale_bytes"], createdAt, float64(zone.Stale.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["updating_responses"], createdAt, float64(zone.Updating.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["updating_bytes"], createdAt, float64(zone.Updating.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["revalidated_responses"], createdAt, float64(zone.Revalidated.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["revalidated_bytes"], createdAt, float64(zone.Revalidated.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["miss_responses"], createdAt, float64(zone.Miss.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["miss_bytes"], createdAt, float64(zone.Miss.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["expired_responses"], createdAt, float64(zone.Expired.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["expired_bytes"], createdAt, float64(zone.Expired.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["expired_responses_written"], createdAt, float64(zone.Expired.ResponsesWritten), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["expired_bytes_written"], createdAt, float64(zone.Expired.BytesWritten), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["bypass_responses"], createdAt, float64(zone.Bypass.Responses), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["bypass_bytes"], createdAt, float64(zone.Bypass.Bytes), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["bypass_responses_written"], createdAt, float64(zone.Bypass.ResponsesWritten), labelValues...)
+		c.newCounterMetric(ch, c.cacheZoneMetrics["bypass_bytes_written"], createdAt, float64(zone.Bypass.BytesWritten), labelValues...)
 	}
 
 	for id, worker := range stats.Workers {
 		workerID := strconv.FormatInt(int64(id), 10)
 		workerPID := strconv.FormatUint(worker.ProcessID, 10)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_accepted"], prometheus.CounterValue, float64(worker.Connections.Accepted), workerID, workerPID)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_dropped"], prometheus.CounterValue, float64(worker.Connections.Dropped), workerID, workerPID)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_active"], prometheus.GaugeValue, float64(worker.Connections.Active), workerID, workerPID)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_idle"], prometheus.GaugeValue, float64(worker.Connections.Idle), workerID, workerPID)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["http_requests_total"], prometheus.CounterValue, float64(worker.HTTP.HTTPRequests.Total), workerID, workerPID)
-		ch <- prometheus.MustNewConstMetric(c.workerMetrics["http_requests_current"], prometheus.GaugeValue, float64(worker.HTTP.HTTPRequests.Current), workerID, workerPID)
+		c.newCounterMetric(ch, c.workerMetrics["connection_accepted"], createdAt, float64(worker.Connections.Accepted), workerID, workerPID)
+		c.newCounterMetric(ch, c.workerMetrics["connection_dropped"], createdAt, float64(worker.Connections.Dropped), workerID, workerPID)
+		c.newGaugeMetric(ch, c.workerMetrics["connection_active"], float64(worker.Connections.Active), workerID, workerPID)
+		c.newGaugeMetric(ch, c.workerMetrics["connection_idle"], float64(worker.Connections.Idle), workerID, workerPID)
+		c.newCounterMetric(ch, c.workerMetrics["http_requests_total"], createdAt, float64(worker.HTTP.HTTPRequests.Total), workerID, workerPID)
+		c.newGaugeMetric(ch, c.workerMetrics["http_requests_current"], float64(worker.HTTP.HTTPRequests.Current), workerID, workerPID)
 	}
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -94,6 +94,9 @@ var (
 	sslClientKey  = kingpin.Flag("nginx.ssl-client-key", "Path to the PEM encoded client certificate key file to use when connecting to the server.").Default("").Envar("SSL_CLIENT_KEY").String()
 	useProxyProto = kingpin.Flag("nginx.proxy-protocol", "Pass proxy protocol payload to nginx listeners.").Default("false").Envar("PROXY_PROTOCOL").Bool()
 
+	// Prometheus format flags.
+	createdTimeSource = kingpin.Flag("prometheus.created-time-source", "Source for created timestamps on counter metrics: none, process, stats (stats is only valid with --nginx.plus).").Default("none").Envar("CREATED_TIME_SOURCE").Enum("none", "process", "stats")
+
 	// Custom command-line flags.
 	timeout = createPositiveDurationFlag(kingpin.Flag("nginx.timeout", "A timeout for scraping metrics from NGINX or NGINX Plus.").Default("5s").Envar("TIMEOUT").HintOptions("5s", "10s", "30s", "1m", "5m"))
 )
@@ -163,15 +166,26 @@ func main() {
 		TLSClientConfig: sslConfig,
 	}
 
+	if !*nginxPlus && *createdTimeSource == "stats" {
+		logger.Error("created-time-source=stats is only valid with --nginx.plus")
+		os.Exit(1)
+	}
+	var ctSource collector.CTSource
+	if *createdTimeSource == "process" {
+		ctSource = collector.CTSourceProcess
+	} else if *createdTimeSource == "stats" {
+		ctSource = collector.CTSourceStats
+	}
+
 	if len(*scrapeURIs) == 1 {
-		registerCollector(logger, transport, (*scrapeURIs)[0], constLabels)
+		registerCollector(logger, transport, (*scrapeURIs)[0], constLabels, ctSource)
 	} else {
 		for _, addr := range *scrapeURIs {
 			// add scrape URI to const labels
 			labels := maps.Clone(constLabels)
 			labels["addr"] = addr
 
-			registerCollector(logger, transport, addr, labels)
+			registerCollector(logger, transport, addr, labels, ctSource)
 		}
 	}
 
@@ -224,7 +238,7 @@ func main() {
 }
 
 func registerCollector(logger *slog.Logger, transport *http.Transport,
-	addr string, labels map[string]string,
+	addr string, labels map[string]string, ctSource collector.CTSource,
 ) {
 	var socketPath string
 
@@ -307,10 +321,10 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 			os.Exit(1)
 		}
 		variableLabelNames := collector.NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil)
-		prometheus.MustRegister(collector.NewNginxPlusCollector(plusClient, "nginxplus", variableLabelNames, labels, logger))
+		prometheus.MustRegister(collector.NewNginxPlusCollector(plusClient, "nginxplus", variableLabelNames, labels, logger, ctSource))
 	} else {
 		ossClient := client.NewNginxClient(httpClient, addr)
-		prometheus.MustRegister(collector.NewNginxCollector(ossClient, "nginx", labels, logger))
+		prometheus.MustRegister(collector.NewNginxCollector(ossClient, "nginx", labels, logger, ctSource))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/nginx/nginx-plus-go-client/v3 v3.0.1
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/exporter-toolkit v0.15.1
 )
@@ -23,7 +24,6 @@ require (
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect


### PR DESCRIPTION
### Proposed changes

Addresses https://github.com/nginx/nginx-prometheus-exporter/issues/1252

- Add an optional `prometheus.created-time-source` flag to specify how created_timestamps for counters are mapped with default setting to `none`
-- `none`: no-op
-- `process`: collector to set CT values for counter metrics using the creation wall time of the collector process 
-- `stats`: nginxPlus only. collector to set CT values from the `load_time` stat
- Integration tests to confirm the proto payload returned by the promhttp endpoint returns expected CT values


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ X ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [ X ] I have proven my fix is effective or that my feature works
- [ X ] I have checked that all unit tests pass after adding my changes
- [ X ] I have ensured the README is up to date
- [ X ] I have rebased my branch onto main
- [ X ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
